### PR TITLE
suit: Fix MAX_NUMBER_OF_MANIFEST_CLASS_IDS default value

### DIFF
--- a/subsys/suit/platform/Kconfig
+++ b/subsys/suit/platform/Kconfig
@@ -25,7 +25,7 @@ config SUIT_DIGEST
 config MAX_NUMBER_OF_MANIFEST_CLASS_IDS
 	int  "Maximum number of supported manifest class IDs that can be handled"
 	range 1 200
-	default 8 if SOC_NRF54H20
+	default 11 if SOC_NRF54H20
 	default 5 if SOC_NRF52840
 	default 5 if SOC_POSIX
 	help


### PR DESCRIPTION
The value was set to 8, which was the maximum amount of user controlled manifests, wheras in reality it should be 11 (plus 3 Nordic Controlled manifests).